### PR TITLE
ENH: hierarchy of EtherCAT terminals

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,3 @@ recommonmark
 sphinx
 sphinx_rtd_theme
 sphinxcontrib-jquery
-# packaging 22.0 breaks some builds by removing LegacyVersion.
-packaging==21.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 docs-versions-menu
 git+https://github.com/pcdshub/ads-deploy/@master
+pytmc >=2.15.0
 recommonmark
 sphinx
 sphinx_rtd_theme

--- a/templates/index.rst
+++ b/templates/index.rst
@@ -9,6 +9,7 @@
 
     {{ tsproj.name }}_pragmas
     {{ tsproj.name }}_nc
+    {{ tsproj.name }}_ethercat
     {{ tsproj.name }}_boxes
     {{ tsproj.name }}_links
 

--- a/templates/{{tsproj.name}}_ethercat.rst
+++ b/templates/{{tsproj.name}}_ethercat.rst
@@ -1,0 +1,45 @@
+{% import "util.macro" as util %}
+
+{%- macro format_box(box, depth) %}
+  {%- if not box.EtherCAT -%}
+    (Not EtherCAT?)
+  {%- else -%}
+    {%- if depth % 2 == 0 -%}
+      **
+    {%- endif %}
+    {{- box.name | trim("=+-") }} [ID: {{ box.attributes.Id }}]
+    {%- if depth % 2 == 0 -%}
+      **
+    {%- endif %}
+    {%- set ethercat = box.EtherCAT[0] %}
+
+    {%+ if box.attributes.Disabled == "true" %}
+      {{ "(**Disabled**)" }}
+    {%- endif %}
+    {%- if ethercat.SuName %}
+      ( **SyncUnit={{ ethercat.SuName[0].text }}** )
+    {%- endif %}
+    {{ ethercat.attributes.Type }}
+  {%- endif -%}
+{%- endmacro -%}
+
+{%- macro format_tree(box, children, depth) %}
+{% set box_text = format_box(box, depth) %}
+#. {{ box_text }}
+
+  {% for child, grandchildren in children.items() %}
+    {% set child_text = format_tree(child, grandchildren, depth + 1) %}
+    {{ child_text | indent(width=4, first=False, blank=False) }}
+
+  {% endfor %}
+{%- endmacro -%}
+
+
+{{ util.section("Box Hierarchy") }}
+
+{% for box, children in get_box_hierarchy(tsproj.obj).items() %}
+
+{% set child_text = format_tree(box, children, 0) %}
+{{ child_text }}
+
+{% endfor %}{# for box_id... #}


### PR DESCRIPTION
This update adds a hierarchy of EtherCAT terminals in the form of nested numbered lists:

<img width="706" alt="image" src="https://user-images.githubusercontent.com/5139267/231227876-5a292772-f043-4d68-a3a6-ae31bf879edd.png">


Also closes #4 

