### PR TITLE
DOC: rework ethercat terminal docs page + fix width

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,10 @@ Details on available filters and variables may be found in
 1. [ads-deploy docs](https://github.com/pcdshub/ads-deploy/blob/master/ads_deploy/docs.py)
 2. [pytmc template](https://github.com/pcdshub/pytmc/blob/master/pytmc/bin/template.py)
 2. [pytmc parser](https://github.com/pcdshub/pytmc/blob/master/pytmc/parser.py)
+
+
+## Example
+
+Examples of documentation generated from this repository:
+1. [lcls-plc-rixs-optics](https://pcdshub.github.io/lcls-plc-rixs-optics), a PLC project
+2. [lcls-twincat-general](https://pcdshub.github.io/lcls-twincat-general/), a PLC library

--- a/source/_static/expand-collapse.svg
+++ b/source/_static/expand-collapse.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="40" height="20">
+  <g fill="#fff">
+    <path d="m5 9h4v-4h2v4h4v2h-4v4h-2v-4h-4z"/>
+    <path d="m25 9h10v2h-10z"/>
+  </g>
+</svg>

--- a/source/_static/tree.css
+++ b/source/_static/tree.css
@@ -1,0 +1,88 @@
+/* Adapted from https://iamkate.com/code/tree-views/ - thanks! */
+
+.tree{
+  --spacing : 1.5rem;
+  --radius  : 10px;
+}
+
+.tree li{
+  display      : block;
+  position     : relative;
+  padding-left : calc(2 * var(--spacing) - var(--radius) - 2px);
+}
+
+.tree ul{
+  margin-left  : calc(var(--radius) - var(--spacing));
+  padding-left : 0;
+}
+
+.tree ul li{
+  border-left : 2px solid #ddd;
+}
+
+.tree ul li:last-child{
+  border-color : transparent;
+}
+
+.tree ul li::before{
+  content      : '';
+  display      : block;
+  position     : absolute;
+  top          : calc(var(--spacing) / -2);
+  left         : -2px;
+  width        : calc(var(--spacing) + 2px);
+  height       : calc(var(--spacing) + 1px);
+  border       : solid #ddd;
+  border-width : 0 0 2px 2px;
+}
+
+.tree summary{
+  display : block;
+  cursor  : pointer;
+}
+
+.tree summary::marker,
+.tree summary::-webkit-details-marker{
+  display : none;
+}
+
+.tree summary:focus{
+  outline : none;
+}
+
+.tree summary:focus-visible{
+  outline : 1px dotted #000;
+}
+
+.tree summary::before{
+  content       : '';
+  display       : block;
+  position      : absolute;
+  top           : calc(var(--spacing) / 2 - var(--radius));
+  left          : calc(var(--spacing) - var(--radius) - 1px);
+  width         : calc(2 * var(--radius));
+  height        : calc(2 * var(--radius));
+  border-radius : 50%;
+  background    : #ddd;
+}
+
+.tree li::after {
+  content       : '';
+  display       : block;
+  position      : absolute;
+  top           : calc(var(--spacing) / 2 - var(--radius));
+  left          : calc(var(--spacing) - var(--radius) - 1px);
+  width         : calc(2 * var(--radius));
+  height        : calc(2 * var(--radius));
+  border-radius : 50%;
+  background    : transparent;
+}
+
+.tree summary::before{
+  z-index    : 1;
+  background : #696 url('expand-collapse.svg') 0 0;
+}
+
+.tree details[open] > summary::before{
+  background-position : calc(-2 * var(--radius)) 0;
+}

--- a/source/_static/width.css
+++ b/source/_static/width.css
@@ -1,0 +1,3 @@
+.wy-nav-content {
+   max-width: none;
+}

--- a/source/conf.py
+++ b/source/conf.py
@@ -76,6 +76,7 @@ html_theme = "sphinx_rtd_theme"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+html_css_files = ["tree.css", "width.css"]
 
 source_suffix = {
     '.rst': 'restructuredtext',

--- a/templates/{{tsproj.name}}_ethercat.rst
+++ b/templates/{{tsproj.name}}_ethercat.rst
@@ -1,45 +1,78 @@
 {% import "util.macro" as util %}
 
-{%- macro format_box(box, depth) %}
+{% macro format_box_html(box, depth) %}
   {%- if not box.EtherCAT -%}
     (Not EtherCAT?)
   {%- else -%}
-    {%- if depth % 2 == 0 -%}
-      **
-    {%- endif %}
-    {{- box.name | trim("=+-") }} [ID: {{ box.attributes.Id }}]
-    {%- if depth % 2 == 0 -%}
-      **
-    {%- endif %}
     {%- set ethercat = box.EtherCAT[0] %}
-
-    {%+ if box.attributes.Disabled == "true" %}
-      {{ "(**Disabled**)" }}
-    {%- endif %}
-    {%- if ethercat.SuName %}
-      ( **SyncUnit={{ ethercat.SuName[0].text }}** )
-    {%- endif %}
-    {{ ethercat.attributes.Type }}
+    <table width="100%">
+      <tr>
+        <td width="10%">
+          ID={{ box.attributes.Id }}:
+        </td>
+        <td width="75%">
+          {{- box.name | trim("=+-") }}
+        </td>
+        <td>
+          {%- if ethercat.SuName %}
+            <b>
+              SyncUnit {{ ethercat.SuName[0].text }}
+            </b>
+          {%- endif %}
+        </td>
+      </tr>
+      <tr>
+        <td>
+          {%+ if box.attributes.Disabled == "true" %}
+            <b>
+              Disabled
+            </b>
+          {%- endif %}
+        </td>
+        <td colspan="2">
+          {{ ethercat.attributes.Type }}
+        </td>
+      </tr>
+    </table>
   {%- endif -%}
 {%- endmacro -%}
 
-{%- macro format_tree(box, children, depth) %}
-{% set box_text = format_box(box, depth) %}
-#. {{ box_text }}
+{%- macro format_tree_html(box, children, depth) %}
+  {% set box_text = format_box_html(box, depth) %}
+  <li>
+  {% if not children %}
+    {{ box_text }}
+  {% else %}
+    <details open>
+      <summary>
+        {{ box_text }}
+      </summary>
+      <ul>
+        {% for child, grandchildren in children.items() %}
 
-  {% for child, grandchildren in children.items() %}
-    {% set child_text = format_tree(child, grandchildren, depth + 1) %}
-    {{ child_text | indent(width=4, first=False, blank=False) }}
+          {% set child_text = format_tree_html(child, grandchildren, depth + 1) %}
+          {{ child_text | indent(width=10, first=False, blank=False) }}
 
-  {% endfor %}
+        {% endfor %}
+      </ul>
+    </details>
+  {% endif %}
+  </li>
+
 {%- endmacro -%}
 
+{{ util.section("EtherCAT Terminals") }}
 
-{{ util.section("Box Hierarchy") }}
+.. raw:: html
+
+    <ul class="tree">
 
 {% for box, children in get_box_hierarchy(tsproj.obj).items() %}
 
-{% set child_text = format_tree(box, children, 0) %}
-{{ child_text }}
+{% set child_text = format_tree_html(box, children, 0) %}
+
+    {{ child_text }}
 
 {% endfor %}{# for box_id... #}
+
+    </ul>


### PR DESCRIPTION
Closes #3 
Closes #7 

Tested locally.

Looks like this:
<img width="1792" alt="image" src="https://github.com/pcdshub/twincat-docs-template/assets/5139267/4047e71c-3ad5-4542-bab0-e7e470949dad">
(scrolling down to the syncunit)
<img width="1392" alt="image" src="https://github.com/pcdshub/twincat-docs-template/assets/5139267/20d831a9-8ae5-4150-8d3b-c4abe9e09bbe">
